### PR TITLE
refactor: 디자인 사이즈 및 weight 조정

### DIFF
--- a/lib/core/theme/app_typography.dart
+++ b/lib/core/theme/app_typography.dart
@@ -7,8 +7,9 @@ abstract class AppTypography {
   // Font Weights
   static const FontWeight light = FontWeight.w300;
   static const FontWeight regular = FontWeight.w400;
+  static const FontWeight medium = FontWeight.w500;
+  static const FontWeight semibold = FontWeight.w600;
   static const FontWeight bold = FontWeight.w700;
-  static const FontWeight extraBold = FontWeight.w800;
 
   // ============================================
   // Display - 큰 숫자, 금액
@@ -16,13 +17,13 @@ abstract class AppTypography {
   static const TextStyle displayLarge = TextStyle(
     fontFamily: fontFamily,
     fontSize: 32,
-    fontWeight: extraBold,
+    fontWeight: bold,
   );
 
   static const TextStyle displaySmall = TextStyle(
     fontFamily: fontFamily,
     fontSize: 24,
-    fontWeight: extraBold,
+    fontWeight: bold,
   );
 
   // ============================================
@@ -37,7 +38,7 @@ abstract class AppTypography {
   static const TextStyle headlineSmall = TextStyle(
     fontFamily: fontFamily,
     fontSize: 18,
-    fontWeight: bold,
+    fontWeight: semibold,
   );
 
   // ============================================
@@ -46,13 +47,13 @@ abstract class AppTypography {
   static const TextStyle titleLarge = TextStyle(
     fontFamily: fontFamily,
     fontSize: 16,
-    fontWeight: bold,
+    fontWeight: semibold,
   );
 
   static const TextStyle titleSmall = TextStyle(
     fontFamily: fontFamily,
     fontSize: 14,
-    fontWeight: bold,
+    fontWeight: medium,
   );
 
   // ============================================
@@ -76,13 +77,13 @@ abstract class AppTypography {
   static const TextStyle labelLarge = TextStyle(
     fontFamily: fontFamily,
     fontSize: 14,
-    fontWeight: bold,
+    fontWeight: medium,
   );
 
   static const TextStyle labelSmall = TextStyle(
     fontFamily: fontFamily,
     fontSize: 12,
-    fontWeight: bold,
+    fontWeight: medium,
   );
 
   // ============================================

--- a/lib/presentation/common/widgets/amount_button.dart
+++ b/lib/presentation/common/widgets/amount_button.dart
@@ -19,15 +19,15 @@ class AmountButton extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 56,
-        height: 56,
+        width: 48,
+        height: 48,
         decoration: BoxDecoration(
           color: isPrimary ? colorScheme.primary : colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(12),
         ),
         child: Icon(
           icon,
-          size: 28,
+          size: 24,
           color: isPrimary ? Colors.white : colorScheme.onSurface,
         ),
       ),

--- a/lib/presentation/common/widgets/app_card.dart
+++ b/lib/presentation/common/widgets/app_card.dart
@@ -15,10 +15,10 @@ class AppCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: padding ?? const EdgeInsets.all(16),
+      padding: padding ?? const EdgeInsets.all(14),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(borderRadius ?? 16),
+        borderRadius: BorderRadius.circular(borderRadius ?? 12),
       ),
       child: child,
     );


### PR DESCRIPTION
## Summary
- AppCard/AmountButton 사이즈 축소 (덜 큼직하게)
- borderRadius 16→12 (덜 동글동글하게)
- Typography weight M3 기준 조정 (extraBold 제거)

## Note
- "젊고 생동감 + 똑부러지는" 느낌 목표
- M3/iOS HIG 참고하여 weight 표준화