### PR TITLE
refactor: 데이터 레이어 네이밍 컨벤션 적용

### DIFF
--- a/lib/core/di/data/datasource_providers.dart
+++ b/lib/core/di/data/datasource_providers.dart
@@ -3,6 +3,7 @@ import 'package:subby/core/di/database_provider.dart';
 import 'package:subby/data/datasource/firebase_auth_datasource.dart';
 import 'package:subby/data/datasource/group_local_datasource.dart';
 import 'package:subby/data/datasource/group_remote_datasource.dart';
+import 'package:subby/data/datasource/pending_change_local_datasource.dart';
 import 'package:subby/data/datasource/preset_local_datasource.dart';
 import 'package:subby/data/datasource/preset_remote_datasource.dart';
 import 'package:subby/data/datasource/subscription_local_datasource.dart';
@@ -35,4 +36,10 @@ final presetLocalDataSourceProvider = Provider<PresetLocalDataSource>((ref) {
   final db = ref.watch(databaseProvider);
 
   return PresetLocalDataSource(db);
+});
+
+final pendingChangeLocalDataSourceProvider = Provider<PendingChangeLocalDataSource>((ref) {
+  final db = ref.watch(databaseProvider);
+
+  return PendingChangeLocalDataSource(db);
 });

--- a/lib/core/di/domain/repository_providers.dart
+++ b/lib/core/di/domain/repository_providers.dart
@@ -2,10 +2,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subby/core/di/data/datasource_providers.dart';
 import 'package:subby/data/repository/auth_repository_impl.dart';
 import 'package:subby/data/repository/group_repository_impl.dart';
+import 'package:subby/data/repository/pending_change_repository_impl.dart';
 import 'package:subby/data/repository/preset_repository_impl.dart';
 import 'package:subby/data/repository/subscription_repository_impl.dart';
 import 'package:subby/domain/repository/auth_repository.dart';
 import 'package:subby/domain/repository/group_repository.dart';
+import 'package:subby/domain/repository/pending_change_repository.dart';
 import 'package:subby/domain/repository/preset_repository.dart';
 import 'package:subby/domain/repository/subscription_repository.dart';
 
@@ -36,4 +38,10 @@ final presetRepositoryProvider = Provider<PresetRepository>((ref) {
     remoteDataSource: remoteDataSource,
     localDataSource: localDataSource,
   );
+});
+
+final pendingChangeRepositoryProvider = Provider<PendingChangeRepository>((ref) {
+  final localDataSource = ref.watch(pendingChangeLocalDataSourceProvider);
+
+  return PendingChangeRepositoryImpl(localDataSource);
 });

--- a/lib/core/di/domain/usecase_providers.dart
+++ b/lib/core/di/domain/usecase_providers.dart
@@ -23,10 +23,12 @@ final initializeAppUseCaseProvider = Provider<InitializeAppUseCase>((ref) {
 final createGroupUseCaseProvider = Provider<CreateGroupUseCase>((ref) {
   final authRepository = ref.watch(authRepositoryProvider);
   final groupRepository = ref.watch(groupRepositoryProvider);
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
 
   return CreateGroupUseCase(
     authRepository: authRepository,
     groupRepository: groupRepository,
+    pendingChangeRepository: pendingChangeRepository,
   );
 });
 
@@ -34,11 +36,13 @@ final leaveGroupUseCaseProvider = Provider<LeaveGroupUseCase>((ref) {
   final authRepository = ref.watch(authRepositoryProvider);
   final groupRepository = ref.watch(groupRepositoryProvider);
   final subscriptionRepository = ref.watch(subscriptionRepositoryProvider);
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
 
   return LeaveGroupUseCase(
     authRepository: authRepository,
     groupRepository: groupRepository,
     subscriptionRepository: subscriptionRepository,
+    pendingChangeRepository: pendingChangeRepository,
   );
 });
 

--- a/lib/data/datasource/pending_change_local_datasource.dart
+++ b/lib/data/datasource/pending_change_local_datasource.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:subby/data/database/database.dart';
+import 'package:subby/data/dto/group_dto.dart';
 import 'package:subby/data/dto/pending_change_dto.dart';
 
 class PendingChangeLocalDataSource {
@@ -33,5 +36,36 @@ class PendingChangeLocalDataSource {
 
   Future<void> deleteAll() async {
     await _db.delete(_db.pendingChanges).go();
+  }
+
+  Future<void> saveGroupChange(
+    GroupDto dto,
+    String action,
+    String entityId,
+  ) async {
+    final pendingDto = PendingChangeDto(
+      entityId: entityId,
+      entityType: 'group',
+      action: action,
+      payload: jsonEncode(dto.toJson()),
+      createdAt: DateTime.now(),
+    );
+
+    await upsert(pendingDto);
+  }
+
+  Future<List<(PendingChangeDto, GroupDto?)>> getGroupChanges() async {
+    final rows = await (_db.select(_db.pendingChanges)
+          ..where((t) => t.entityType.equals('group'))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+
+    return rows.map((row) {
+      final changeDto = row.toDto();
+      final groupDto = changeDto.payload.isNotEmpty
+          ? GroupDto.fromJson(jsonDecode(changeDto.payload))
+          : null;
+      return (changeDto, groupDto);
+    }).toList();
   }
 }

--- a/lib/data/dto/group_dto.dart
+++ b/lib/data/dto/group_dto.dart
@@ -6,6 +6,7 @@ class GroupDto {
   final String name;
   final String? displayName;
   final String ownerId;
+  final List<String> members;
   final DateTime createdAt;
   final DateTime? updatedAt;
 
@@ -14,18 +15,46 @@ class GroupDto {
     required this.name,
     this.displayName,
     required this.ownerId,
+    required this.members,
     required this.createdAt,
     this.updatedAt,
   });
+
+  factory GroupDto.fromJson(Map<String, dynamic> json) {
+    return GroupDto(
+      code: json['code'] as String,
+      name: json['name'] as String,
+      displayName: json['displayName'] as String?,
+      ownerId: json['ownerId'] as String,
+      members: List<String>.from(json['members'] ?? []),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(json['createdAt'] as int),
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(json['updatedAt'] as int)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'code': code,
+      'name': name,
+      'displayName': displayName,
+      'ownerId': ownerId,
+      'members': members,
+      'createdAt': createdAt.millisecondsSinceEpoch,
+      'updatedAt': updatedAt?.millisecondsSinceEpoch,
+    };
+  }
 }
 
-extension SubscriptionGroupEntityToDto on SubscriptionGroup {
+extension SubscriptionGroupRowToDto on SubscriptionGroup {
   GroupDto toDto() {
     return GroupDto(
       code: code,
       name: name,
       displayName: displayName,
       ownerId: ownerId,
+      members: [ownerId],
       createdAt: createdAt,
       updatedAt: updatedAt,
     );

--- a/lib/data/mapper/group_mapper.dart
+++ b/lib/data/mapper/group_mapper.dart
@@ -1,5 +1,22 @@
 import 'package:subby/data/dto/group_dto.dart';
+import 'package:subby/data/response/group_response.dart';
 import 'package:subby/domain/model/subscription_group.dart';
+
+extension GroupResponseToDto on GroupResponse {
+  GroupDto toDto() {
+    return GroupDto(
+      code: code,
+      name: name,
+      displayName: null,
+      ownerId: ownerId,
+      members: members,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
+      updatedAt: updatedAt != null
+          ? DateTime.fromMillisecondsSinceEpoch(updatedAt!)
+          : null,
+    );
+  }
+}
 
 extension GroupDtoToDomain on GroupDto {
   SubscriptionGroup toDomain() {
@@ -8,7 +25,7 @@ extension GroupDtoToDomain on GroupDto {
       name: name,
       displayName: displayName,
       ownerId: ownerId,
-      members: [ownerId],
+      members: members,
       createdAt: createdAt,
       updatedAt: updatedAt,
     );
@@ -22,6 +39,7 @@ extension SubscriptionGroupToDto on SubscriptionGroup {
       name: name,
       displayName: displayName,
       ownerId: ownerId,
+      members: members,
       createdAt: createdAt,
       updatedAt: updatedAt,
     );

--- a/lib/data/repository/group_repository_impl.dart
+++ b/lib/data/repository/group_repository_impl.dart
@@ -30,9 +30,11 @@ class GroupRepositoryImpl implements GroupRepository {
 
   @override
   Future<void> create(SubscriptionGroup group) async {
-    await _localDataSource.insert(group.toDto());
+    final dto = group.toDto();
+
+    await _localDataSource.insert(dto);
     try {
-      await _remoteDataSource.saveGroup(group);
+      await _remoteDataSource.saveGroup(dto);
     } catch (e) {
       throw FirebaseSyncException(e);
     }
@@ -40,9 +42,11 @@ class GroupRepositoryImpl implements GroupRepository {
 
   @override
   Future<void> update(SubscriptionGroup group) async {
-    await _localDataSource.update(group.toDto());
+    final dto = group.toDto();
+
+    await _localDataSource.update(dto);
     try {
-      await _remoteDataSource.saveGroup(group);
+      await _remoteDataSource.saveGroup(dto);
     } catch (e) {
       throw FirebaseSyncException(e);
     }
@@ -79,12 +83,12 @@ class GroupRepositoryImpl implements GroupRepository {
 
   @override
   Future<void> syncCreate(SubscriptionGroup group) async {
-    await _remoteDataSource.saveGroup(group);
+    await _remoteDataSource.saveGroup(group.toDto());
   }
 
   @override
   Future<void> syncUpdate(SubscriptionGroup group) async {
-    await _remoteDataSource.saveGroup(group);
+    await _remoteDataSource.saveGroup(group.toDto());
   }
 
   @override

--- a/lib/data/repository/pending_change_repository_impl.dart
+++ b/lib/data/repository/pending_change_repository_impl.dart
@@ -1,6 +1,8 @@
 import 'package:subby/data/datasource/pending_change_local_datasource.dart';
+import 'package:subby/data/mapper/group_mapper.dart';
 import 'package:subby/data/mapper/pending_change_mapper.dart';
 import 'package:subby/domain/model/pending_change.dart';
+import 'package:subby/domain/model/subscription_group.dart';
 import 'package:subby/domain/repository/pending_change_repository.dart';
 
 class PendingChangeRepositoryImpl implements PendingChangeRepository {
@@ -58,5 +60,26 @@ class PendingChangeRepositoryImpl implements PendingChangeRepository {
   @override
   Future<void> deleteAll() async {
     await _localDataSource.deleteAll();
+  }
+
+  @override
+  Future<void> saveGroupChange(
+    SubscriptionGroup group,
+    ChangeAction action,
+  ) async {
+    final dto = group.toDto();
+
+    await _localDataSource.saveGroupChange(dto, action.name, group.code);
+  }
+
+  @override
+  Future<List<(PendingChange, SubscriptionGroup?)>> getGroupChanges() async {
+    final results = await _localDataSource.getGroupChanges();
+
+    return results.map((tuple) {
+      final change = tuple.$1.toDomain();
+      final group = tuple.$2?.toDomain();
+      return (change, group);
+    }).toList();
   }
 }

--- a/lib/data/response/group_response.dart
+++ b/lib/data/response/group_response.dart
@@ -1,0 +1,49 @@
+class GroupResponse {
+  final String code;
+  final String name;
+  final String ownerId;
+  final List<String> members;
+  final int createdAt;
+  final int? updatedAt;
+
+  GroupResponse({
+    required this.code,
+    required this.name,
+    required this.ownerId,
+    required this.members,
+    required this.createdAt,
+    this.updatedAt,
+  });
+
+  factory GroupResponse.fromJson(Map<String, dynamic> json) {
+    List<String> memberList = [];
+
+    if (json['members'] != null) {
+      if (json['members'] is Map) {
+        memberList = (json['members'] as Map).keys.cast<String>().toList();
+      } else if (json['members'] is List) {
+        memberList = List<String>.from(json['members']);
+      }
+    }
+
+    return GroupResponse(
+      code: json['code'] as String,
+      name: json['name'] as String,
+      ownerId: json['ownerId'] as String,
+      members: memberList,
+      createdAt: json['createdAt'] as int,
+      updatedAt: json['updatedAt'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'code': code,
+      'name': name,
+      'ownerId': ownerId,
+      'members': {for (var uid in members) uid: true},
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+    };
+  }
+}

--- a/lib/domain/model/subscription_group.dart
+++ b/lib/domain/model/subscription_group.dart
@@ -42,43 +42,6 @@ class SubscriptionGroup {
     );
   }
 
-  /// Firestore JSON으로 변환
-  /// members는 map 형태로 저장 (Security Rules 활용 용이)
-  Map<String, dynamic> toJson() {
-    return {
-      'code': code,
-      'name': name,
-      'ownerId': ownerId,
-      'members': {for (var uid in members) uid: true},
-      'createdAt': createdAt.millisecondsSinceEpoch,
-      'updatedAt': updatedAt?.millisecondsSinceEpoch,
-    };
-  }
-
-  /// Firestore JSON에서 생성
-  factory SubscriptionGroup.fromJson(Map<String, dynamic> json) {
-    // members가 map 형태인 경우 key 목록 추출
-    List<String> memberList = [];
-    if (json['members'] != null) {
-      if (json['members'] is Map) {
-        memberList = (json['members'] as Map).keys.cast<String>().toList();
-      } else if (json['members'] is List) {
-        memberList = List<String>.from(json['members']);
-      }
-    }
-
-    return SubscriptionGroup(
-      code: json['code'] as String,
-      name: json['name'] as String,
-      ownerId: json['ownerId'] as String,
-      members: memberList,
-      createdAt: DateTime.fromMillisecondsSinceEpoch(json['createdAt'] as int),
-      updatedAt: json['updatedAt'] != null
-          ? DateTime.fromMillisecondsSinceEpoch(json['updatedAt'] as int)
-          : null,
-    );
-  }
-
   /// 그룹장 여부 확인
   bool isOwner(String userId) => ownerId == userId;
 

--- a/lib/domain/model/user_subscription.dart
+++ b/lib/domain/model/user_subscription.dart
@@ -74,49 +74,4 @@ class UserSubscription {
       syncStatus: syncStatus ?? this.syncStatus,
     );
   }
-
-  /// Firestore JSON으로 변환
-  Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'groupCode': groupCode,
-      'name': name,
-      'amount': amount,
-      'currency': currency,
-      'billingDay': billingDay,
-      'period': period,
-      'category': category,
-      'memo': memo,
-      'feeRatePercent': feeRatePercent,
-      'createdAt': createdAt.millisecondsSinceEpoch,
-      'createdBy': createdBy,
-      'lastModifiedBy': lastModifiedBy,
-      'updatedAt': updatedAt?.millisecondsSinceEpoch,
-    };
-  }
-
-  /// Firestore JSON에서 생성
-  factory UserSubscription.fromJson(Map<String, dynamic> json) {
-    return UserSubscription(
-      id: json['id'] as String,
-      groupCode: json['groupCode'] as String,
-      name: json['name'] as String,
-      amount: (json['amount'] as num).toDouble(),
-      currency: json['currency'] as String,
-      billingDay: json['billingDay'] as int,
-      period: json['period'] as String,
-      category: json['category'] as String?,
-      memo: json['memo'] as String?,
-      feeRatePercent: json['feeRatePercent'] != null
-          ? (json['feeRatePercent'] as num).toDouble()
-          : null,
-      createdAt: DateTime.fromMillisecondsSinceEpoch(json['createdAt'] as int),
-      createdBy: json['createdBy'] as String?,
-      lastModifiedBy: json['lastModifiedBy'] as String?,
-      updatedAt: json['updatedAt'] != null
-          ? DateTime.fromMillisecondsSinceEpoch(json['updatedAt'] as int)
-          : null,
-      syncStatus: SyncStatus.synced,
-    );
-  }
 }

--- a/lib/domain/repository/pending_change_repository.dart
+++ b/lib/domain/repository/pending_change_repository.dart
@@ -1,4 +1,5 @@
 import 'package:subby/domain/model/pending_change.dart';
+import 'package:subby/domain/model/subscription_group.dart';
 
 abstract class PendingChangeRepository {
   Future<List<PendingChange>> getAll();
@@ -6,4 +7,7 @@ abstract class PendingChangeRepository {
   Future<void> save(PendingChange change);
   Future<void> delete(String entityId);
   Future<void> deleteAll();
+
+  Future<void> saveGroupChange(SubscriptionGroup group, ChangeAction action);
+  Future<List<(PendingChange, SubscriptionGroup?)>> getGroupChanges();
 }

--- a/lib/domain/usecase/create_group_usecase.dart
+++ b/lib/domain/usecase/create_group_usecase.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:subby/core/error/firebase_sync_exception.dart';
 import 'package:subby/core/util/group_code_generator.dart';
 import 'package:subby/domain/model/pending_change.dart';
@@ -47,14 +45,9 @@ class CreateGroupUseCase {
     try {
       await _groupRepository.create(newGroup);
     } on FirebaseSyncException {
-      await _pendingChangeRepository.save(
-        PendingChange(
-          entityId: newGroup.code,
-          entityType: EntityType.group,
-          action: ChangeAction.create,
-          payload: jsonEncode(newGroup.toJson()),
-          createdAt: DateTime.now(),
-        ),
+      await _pendingChangeRepository.saveGroupChange(
+        newGroup,
+        ChangeAction.create,
       );
     }
 

--- a/lib/domain/usecase/leave_group_usecase.dart
+++ b/lib/domain/usecase/leave_group_usecase.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:subby/core/error/firebase_sync_exception.dart';
 import 'package:subby/domain/model/pending_change.dart';
 import 'package:subby/domain/repository/auth_repository.dart';
@@ -36,7 +34,7 @@ class LeaveGroupUseCase {
           entityId: groupCode,
           entityType: EntityType.group,
           action: ChangeAction.delete,
-          payload: jsonEncode({'userId': userId}),
+          payload: '',
           createdAt: DateTime.now(),
         ),
       );

--- a/lib/domain/usecase/process_pending_changes_usecase.dart
+++ b/lib/domain/usecase/process_pending_changes_usecase.dart
@@ -1,55 +1,43 @@
-import 'dart:convert';
-
 import 'package:subby/domain/model/pending_change.dart';
-import 'package:subby/domain/model/subscription_group.dart';
+import 'package:subby/domain/repository/auth_repository.dart';
 import 'package:subby/domain/repository/group_repository.dart';
 import 'package:subby/domain/repository/pending_change_repository.dart';
 
 class ProcessPendingChangesUseCase {
   final PendingChangeRepository _pendingChangeRepository;
   final GroupRepository _groupRepository;
+  final AuthRepository _authRepository;
 
   ProcessPendingChangesUseCase(
     this._pendingChangeRepository,
     this._groupRepository,
+    this._authRepository,
   );
 
   Future<void> call() async {
-    final pendingChanges = await _pendingChangeRepository.getAll();
+    await _processGroupChanges();
+    // TODO: _processSubscriptionChanges() 구독 Firebase 연동 후 구현
+  }
 
-    for (final change in pendingChanges) {
+  Future<void> _processGroupChanges() async {
+    final groupChanges = await _pendingChangeRepository.getGroupChanges();
+
+    for (final (change, group) in groupChanges) {
       try {
-        await _processChange(change);
+        switch (change.action) {
+          case ChangeAction.create:
+            if (group != null) await _groupRepository.syncCreate(group);
+          case ChangeAction.update:
+            if (group != null) await _groupRepository.syncUpdate(group);
+          case ChangeAction.delete:
+            final userId = _authRepository.currentUserId!;
+            await _groupRepository.syncLeave(change.entityId, userId);
+        }
+
         await _pendingChangeRepository.delete(change.entityId);
       } catch (e) {
         continue;
       }
-    }
-  }
-
-  Future<void> _processChange(PendingChange change) async {
-    switch (change.entityType) {
-      case EntityType.subscription:
-        // TODO: 구독 Firebase 연동 후 구현
-        break;
-      case EntityType.group:
-        await _processGroupChange(change);
-    }
-  }
-
-  Future<void> _processGroupChange(PendingChange change) async {
-    final json = jsonDecode(change.payload) as Map<String, dynamic>;
-
-    switch (change.action) {
-      case ChangeAction.create:
-        final group = SubscriptionGroup.fromJson(json);
-        await _groupRepository.syncCreate(group);
-      case ChangeAction.update:
-        final group = SubscriptionGroup.fromJson(json);
-        await _groupRepository.syncUpdate(group);
-      case ChangeAction.delete:
-        final userId = json['userId'] as String;
-        await _groupRepository.syncLeave(change.entityId, userId);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Response/Dto/Model 레이어별 명칭 분리
- Domain Model에서 직렬화 로직 제거, DataSource로 이동
- PendingChange 저장/조회 레이어 책임 분리