### PR TITLE
feat: 구독 Firebase 동기화 구현

### DIFF
--- a/lib/core/di/data/datasource_providers.dart
+++ b/lib/core/di/data/datasource_providers.dart
@@ -7,6 +7,7 @@ import 'package:subby/data/datasource/pending_change_local_datasource.dart';
 import 'package:subby/data/datasource/preset_local_datasource.dart';
 import 'package:subby/data/datasource/preset_remote_datasource.dart';
 import 'package:subby/data/datasource/subscription_local_datasource.dart';
+import 'package:subby/data/datasource/subscription_remote_datasource.dart';
 
 final firebaseAuthDataSourceProvider = Provider<FirebaseAuthDataSource>((ref) {
   return FirebaseAuthDataSource();
@@ -26,6 +27,10 @@ final subscriptionLocalDataSourceProvider = Provider<SubscriptionLocalDataSource
   final db = ref.watch(databaseProvider);
 
   return SubscriptionLocalDataSource(db);
+});
+
+final subscriptionRemoteDataSourceProvider = Provider<SubscriptionRemoteDataSource>((ref) {
+  return SubscriptionRemoteDataSource();
 });
 
 final presetRemoteDataSourceProvider = Provider<PresetRemoteDataSource>((ref) {

--- a/lib/core/di/domain/repository_providers.dart
+++ b/lib/core/di/domain/repository_providers.dart
@@ -26,8 +26,9 @@ final groupRepositoryProvider = Provider<GroupRepository>((ref) {
 
 final subscriptionRepositoryProvider = Provider<SubscriptionRepository>((ref) {
   final localDataSource = ref.watch(subscriptionLocalDataSourceProvider);
+  final remoteDataSource = ref.watch(subscriptionRemoteDataSourceProvider);
 
-  return SubscriptionRepositoryImpl(localDataSource);
+  return SubscriptionRepositoryImpl(localDataSource, remoteDataSource);
 });
 
 final presetRepositoryProvider = Provider<PresetRepository>((ref) {

--- a/lib/core/di/domain/usecase_providers.dart
+++ b/lib/core/di/domain/usecase_providers.dart
@@ -7,6 +7,7 @@ import 'package:subby/domain/usecase/get_presets_usecase.dart';
 import 'package:subby/domain/usecase/get_subscription_by_id_usecase.dart';
 import 'package:subby/domain/usecase/initialize_app_usecase.dart';
 import 'package:subby/domain/usecase/leave_group_usecase.dart';
+import 'package:subby/domain/usecase/process_pending_changes_usecase.dart';
 import 'package:subby/domain/usecase/update_subscription_usecase.dart';
 import 'package:subby/domain/usecase/watch_subscriptions_usecase.dart';
 
@@ -80,4 +81,18 @@ final getPresetsUseCaseProvider = Provider<GetPresetsUseCase>((ref) {
   final repository = ref.watch(presetRepositoryProvider);
 
   return GetPresetsUseCase(repository);
+});
+
+final processPendingChangesUseCaseProvider = Provider<ProcessPendingChangesUseCase>((ref) {
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
+  final groupRepository = ref.watch(groupRepositoryProvider);
+  final subscriptionRepository = ref.watch(subscriptionRepositoryProvider);
+  final authRepository = ref.watch(authRepositoryProvider);
+
+  return ProcessPendingChangesUseCase(
+    pendingChangeRepository,
+    groupRepository,
+    subscriptionRepository,
+    authRepository,
+  );
 });

--- a/lib/core/di/domain/usecase_providers.dart
+++ b/lib/core/di/domain/usecase_providers.dart
@@ -55,8 +55,9 @@ final watchSubscriptionsUseCaseProvider = Provider<WatchSubscriptionsUseCase>((r
 
 final addSubscriptionUseCaseProvider = Provider<AddSubscriptionUseCase>((ref) {
   final repository = ref.watch(subscriptionRepositoryProvider);
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
 
-  return AddSubscriptionUseCase(repository);
+  return AddSubscriptionUseCase(repository, pendingChangeRepository);
 });
 
 final getSubscriptionByIdUseCaseProvider = Provider<GetSubscriptionByIdUseCase>((ref) {

--- a/lib/core/di/domain/usecase_providers.dart
+++ b/lib/core/di/domain/usecase_providers.dart
@@ -68,8 +68,9 @@ final getSubscriptionByIdUseCaseProvider = Provider<GetSubscriptionByIdUseCase>(
 
 final updateSubscriptionUseCaseProvider = Provider<UpdateSubscriptionUseCase>((ref) {
   final repository = ref.watch(subscriptionRepositoryProvider);
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
 
-  return UpdateSubscriptionUseCase(repository);
+  return UpdateSubscriptionUseCase(repository, pendingChangeRepository);
 });
 
 final deleteSubscriptionUseCaseProvider = Provider<DeleteSubscriptionUseCase>((ref) {

--- a/lib/core/di/domain/usecase_providers.dart
+++ b/lib/core/di/domain/usecase_providers.dart
@@ -75,8 +75,9 @@ final updateSubscriptionUseCaseProvider = Provider<UpdateSubscriptionUseCase>((r
 
 final deleteSubscriptionUseCaseProvider = Provider<DeleteSubscriptionUseCase>((ref) {
   final repository = ref.watch(subscriptionRepositoryProvider);
+  final pendingChangeRepository = ref.watch(pendingChangeRepositoryProvider);
 
-  return DeleteSubscriptionUseCase(repository);
+  return DeleteSubscriptionUseCase(repository, pendingChangeRepository);
 });
 
 final getPresetsUseCaseProvider = Provider<GetPresetsUseCase>((ref) {

--- a/lib/data/datasource/pending_change_local_datasource.dart
+++ b/lib/data/datasource/pending_change_local_datasource.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:subby/data/database/database.dart';
 import 'package:subby/data/dto/group_dto.dart';
 import 'package:subby/data/dto/pending_change_dto.dart';
+import 'package:subby/data/dto/subscription_dto.dart';
 
 class PendingChangeLocalDataSource {
   final AppDatabase _db;
@@ -66,6 +67,37 @@ class PendingChangeLocalDataSource {
           ? GroupDto.fromJson(jsonDecode(changeDto.payload))
           : null;
       return (changeDto, groupDto);
+    }).toList();
+  }
+
+  Future<void> saveSubscriptionChange(
+    SubscriptionDto dto,
+    String action,
+    String entityId,
+  ) async {
+    final pendingDto = PendingChangeDto(
+      entityId: entityId,
+      entityType: 'subscription',
+      action: action,
+      payload: jsonEncode(dto.toJson()),
+      createdAt: DateTime.now(),
+    );
+
+    await upsert(pendingDto);
+  }
+
+  Future<List<(PendingChangeDto, SubscriptionDto?)>> getSubscriptionChanges() async {
+    final rows = await (_db.select(_db.pendingChanges)
+          ..where((t) => t.entityType.equals('subscription'))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+
+    return rows.map((row) {
+      final changeDto = row.toDto();
+      final subscriptionDto = changeDto.payload.isNotEmpty
+          ? SubscriptionDto.fromJson(jsonDecode(changeDto.payload))
+          : null;
+      return (changeDto, subscriptionDto);
     }).toList();
   }
 }

--- a/lib/data/datasource/subscription_remote_datasource.dart
+++ b/lib/data/datasource/subscription_remote_datasource.dart
@@ -1,0 +1,55 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:subby/data/dto/subscription_dto.dart';
+import 'package:subby/data/mapper/subscription_mapper.dart';
+import 'package:subby/data/response/subscription_response.dart';
+
+class SubscriptionRemoteDataSource {
+  final FirebaseFirestore _firestore;
+
+  SubscriptionRemoteDataSource() : _firestore = FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> _subscriptionsRef(
+    String groupCode,
+  ) =>
+      _firestore.collection('groups').doc(groupCode).collection('subscriptions');
+
+  Future<void> saveSubscription(SubscriptionDto dto) async {
+    final response = SubscriptionResponse(
+      id: dto.id,
+      groupCode: dto.groupCode,
+      name: dto.name,
+      amount: dto.amount,
+      currency: dto.currency,
+      billingDay: dto.billingDay,
+      period: dto.period,
+      category: dto.category,
+      memo: dto.memo,
+      feeRatePercent: dto.feeRatePercent,
+      createdAt: dto.createdAt.millisecondsSinceEpoch,
+    );
+
+    await _subscriptionsRef(dto.groupCode).doc(dto.id).set(response.toJson());
+  }
+
+  Future<SubscriptionDto?> getSubscription(
+    String groupCode,
+    String subscriptionId,
+  ) async {
+    final doc = await _subscriptionsRef(groupCode).doc(subscriptionId).get();
+
+    if (!doc.exists || doc.data() == null) {
+      return null;
+    }
+
+    final response = SubscriptionResponse.fromJson(doc.data()!);
+
+    return response.toDto();
+  }
+
+  Future<void> deleteSubscription(
+    String groupCode,
+    String subscriptionId,
+  ) async {
+    await _subscriptionsRef(groupCode).doc(subscriptionId).delete();
+  }
+}

--- a/lib/data/dto/subscription_dto.dart
+++ b/lib/data/dto/subscription_dto.dart
@@ -27,6 +27,38 @@ class SubscriptionDto {
     this.feeRatePercent,
     required this.createdAt,
   });
+
+  factory SubscriptionDto.fromJson(Map<String, dynamic> json) {
+    return SubscriptionDto(
+      id: json['id'] as String,
+      groupCode: json['groupCode'] as String,
+      name: json['name'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      currency: json['currency'] as String,
+      billingDay: json['billingDay'] as int,
+      period: json['period'] as String,
+      category: json['category'] as String?,
+      memo: json['memo'] as String?,
+      feeRatePercent: (json['feeRatePercent'] as num?)?.toDouble(),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(json['createdAt'] as int),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'groupCode': groupCode,
+      'name': name,
+      'amount': amount,
+      'currency': currency,
+      'billingDay': billingDay,
+      'period': period,
+      'category': category,
+      'memo': memo,
+      'feeRatePercent': feeRatePercent,
+      'createdAt': createdAt.millisecondsSinceEpoch,
+    };
+  }
 }
 
 extension UserSubscriptionToDto on UserSubscription {

--- a/lib/data/mapper/subscription_mapper.dart
+++ b/lib/data/mapper/subscription_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:subby/data/dto/subscription_dto.dart';
+import 'package:subby/data/response/subscription_response.dart';
 import 'package:subby/domain/model/user_subscription.dart';
 
 extension SubscriptionDtoToDomain on SubscriptionDto {
@@ -33,6 +34,24 @@ extension UserSubscriptionToDto on UserSubscription {
       memo: memo,
       feeRatePercent: feeRatePercent,
       createdAt: createdAt,
+    );
+  }
+}
+
+extension SubscriptionResponseToDto on SubscriptionResponse {
+  SubscriptionDto toDto() {
+    return SubscriptionDto(
+      id: id,
+      groupCode: groupCode,
+      name: name,
+      amount: amount,
+      currency: currency,
+      billingDay: billingDay,
+      period: period,
+      category: category,
+      memo: memo,
+      feeRatePercent: feeRatePercent,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdAt),
     );
   }
 }

--- a/lib/data/repository/pending_change_repository_impl.dart
+++ b/lib/data/repository/pending_change_repository_impl.dart
@@ -1,8 +1,10 @@
 import 'package:subby/data/datasource/pending_change_local_datasource.dart';
 import 'package:subby/data/mapper/group_mapper.dart';
 import 'package:subby/data/mapper/pending_change_mapper.dart';
+import 'package:subby/data/mapper/subscription_mapper.dart';
 import 'package:subby/domain/model/pending_change.dart';
 import 'package:subby/domain/model/subscription_group.dart';
+import 'package:subby/domain/model/user_subscription.dart';
 import 'package:subby/domain/repository/pending_change_repository.dart';
 
 class PendingChangeRepositoryImpl implements PendingChangeRepository {
@@ -80,6 +82,27 @@ class PendingChangeRepositoryImpl implements PendingChangeRepository {
       final change = tuple.$1.toDomain();
       final group = tuple.$2?.toDomain();
       return (change, group);
+    }).toList();
+  }
+
+  @override
+  Future<void> saveSubscriptionChange(
+    UserSubscription subscription,
+    ChangeAction action,
+  ) async {
+    final dto = subscription.toDto();
+
+    await _localDataSource.saveSubscriptionChange(dto, action.name, subscription.id);
+  }
+
+  @override
+  Future<List<(PendingChange, UserSubscription?)>> getSubscriptionChanges() async {
+    final results = await _localDataSource.getSubscriptionChanges();
+
+    return results.map((tuple) {
+      final change = tuple.$1.toDomain();
+      final subscription = tuple.$2?.toDomain();
+      return (change, subscription);
     }).toList();
   }
 }

--- a/lib/data/response/subscription_response.dart
+++ b/lib/data/response/subscription_response.dart
@@ -1,0 +1,59 @@
+class SubscriptionResponse {
+  final String id;
+  final String groupCode;
+  final String name;
+  final double amount;
+  final String currency;
+  final int billingDay;
+  final String period;
+  final String? category;
+  final String? memo;
+  final double? feeRatePercent;
+  final int createdAt;
+
+  SubscriptionResponse({
+    required this.id,
+    required this.groupCode,
+    required this.name,
+    required this.amount,
+    required this.currency,
+    required this.billingDay,
+    required this.period,
+    this.category,
+    this.memo,
+    this.feeRatePercent,
+    required this.createdAt,
+  });
+
+  factory SubscriptionResponse.fromJson(Map<String, dynamic> json) {
+    return SubscriptionResponse(
+      id: json['id'] as String,
+      groupCode: json['groupCode'] as String,
+      name: json['name'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      currency: json['currency'] as String,
+      billingDay: json['billingDay'] as int,
+      period: json['period'] as String,
+      category: json['category'] as String?,
+      memo: json['memo'] as String?,
+      feeRatePercent: (json['feeRatePercent'] as num?)?.toDouble(),
+      createdAt: json['createdAt'] as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'groupCode': groupCode,
+      'name': name,
+      'amount': amount,
+      'currency': currency,
+      'billingDay': billingDay,
+      'period': period,
+      'category': category,
+      'memo': memo,
+      'feeRatePercent': feeRatePercent,
+      'createdAt': createdAt,
+    };
+  }
+}

--- a/lib/domain/repository/pending_change_repository.dart
+++ b/lib/domain/repository/pending_change_repository.dart
@@ -1,5 +1,6 @@
 import 'package:subby/domain/model/pending_change.dart';
 import 'package:subby/domain/model/subscription_group.dart';
+import 'package:subby/domain/model/user_subscription.dart';
 
 abstract class PendingChangeRepository {
   Future<List<PendingChange>> getAll();
@@ -10,4 +11,7 @@ abstract class PendingChangeRepository {
 
   Future<void> saveGroupChange(SubscriptionGroup group, ChangeAction action);
   Future<List<(PendingChange, SubscriptionGroup?)>> getGroupChanges();
+
+  Future<void> saveSubscriptionChange(UserSubscription subscription, ChangeAction action);
+  Future<List<(PendingChange, UserSubscription?)>> getSubscriptionChanges();
 }

--- a/lib/domain/repository/subscription_repository.dart
+++ b/lib/domain/repository/subscription_repository.dart
@@ -8,4 +8,8 @@ abstract class SubscriptionRepository {
   Future<void> delete(String id);
   Future<void> deleteByGroupCode(String groupCode);
   Stream<List<UserSubscription>> watchAll();
+
+  Future<void> syncCreate(UserSubscription subscription);
+  Future<void> syncUpdate(UserSubscription subscription);
+  Future<void> syncDelete(String groupCode, String subscriptionId);
 }

--- a/lib/domain/usecase/add_subscription_usecase.dart
+++ b/lib/domain/usecase/add_subscription_usecase.dart
@@ -1,10 +1,23 @@
+import 'package:subby/core/error/firebase_sync_exception.dart';
+import 'package:subby/domain/model/pending_change.dart';
 import 'package:subby/domain/model/user_subscription.dart';
+import 'package:subby/domain/repository/pending_change_repository.dart';
 import 'package:subby/domain/repository/subscription_repository.dart';
 
 class AddSubscriptionUseCase {
   final SubscriptionRepository _repository;
+  final PendingChangeRepository _pendingChangeRepository;
 
-  AddSubscriptionUseCase(this._repository);
+  AddSubscriptionUseCase(this._repository, this._pendingChangeRepository);
 
-  Future<void> call(UserSubscription subscription) => _repository.create(subscription);
+  Future<void> call(UserSubscription subscription) async {
+    try {
+      await _repository.create(subscription);
+    } on FirebaseSyncException {
+      await _pendingChangeRepository.saveSubscriptionChange(
+        subscription,
+        ChangeAction.create,
+      );
+    }
+  }
 }

--- a/lib/domain/usecase/delete_subscription_usecase.dart
+++ b/lib/domain/usecase/delete_subscription_usecase.dart
@@ -1,9 +1,25 @@
+import 'package:subby/core/error/firebase_sync_exception.dart';
+import 'package:subby/domain/model/pending_change.dart';
+import 'package:subby/domain/repository/pending_change_repository.dart';
 import 'package:subby/domain/repository/subscription_repository.dart';
 
 class DeleteSubscriptionUseCase {
   final SubscriptionRepository _repository;
+  final PendingChangeRepository _pendingChangeRepository;
 
-  DeleteSubscriptionUseCase(this._repository);
+  DeleteSubscriptionUseCase(this._repository, this._pendingChangeRepository);
 
-  Future<void> call(String id) => _repository.delete(id);
+  Future<void> call(String id) async {
+    final subscription = await _repository.getById(id);
+    if (subscription == null) return;
+
+    try {
+      await _repository.delete(id);
+    } on FirebaseSyncException {
+      await _pendingChangeRepository.saveSubscriptionChange(
+        subscription,
+        ChangeAction.delete,
+      );
+    }
+  }
 }

--- a/lib/domain/usecase/update_subscription_usecase.dart
+++ b/lib/domain/usecase/update_subscription_usecase.dart
@@ -1,10 +1,23 @@
+import 'package:subby/core/error/firebase_sync_exception.dart';
+import 'package:subby/domain/model/pending_change.dart';
 import 'package:subby/domain/model/user_subscription.dart';
+import 'package:subby/domain/repository/pending_change_repository.dart';
 import 'package:subby/domain/repository/subscription_repository.dart';
 
 class UpdateSubscriptionUseCase {
   final SubscriptionRepository _repository;
+  final PendingChangeRepository _pendingChangeRepository;
 
-  UpdateSubscriptionUseCase(this._repository);
+  UpdateSubscriptionUseCase(this._repository, this._pendingChangeRepository);
 
-  Future<void> call(UserSubscription subscription) => _repository.update(subscription);
+  Future<void> call(UserSubscription subscription) async {
+    try {
+      await _repository.update(subscription);
+    } on FirebaseSyncException {
+      await _pendingChangeRepository.saveSubscriptionChange(
+        subscription,
+        ChangeAction.update,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- SubscriptionRemoteDataSource 생성 및 Repository 연동
- Add/Update/Delete UseCase에 Firebase 동기화 및 오프라인 처리 추가
- ProcessPendingChangesUseCase에 subscription 케이스 구현