### PR TITLE
fix: 포그라운드 복귀 시 동기화 재시작

### DIFF
--- a/lib/presentation/common/app_initialization_wrapper.dart
+++ b/lib/presentation/common/app_initialization_wrapper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:subby/core/di/data/service_providers.dart';
 import 'package:subby/core/util/invite_link_generator.dart';
 import 'package:subby/presentation/common/providers/app_state_providers.dart';
 import 'package:subby/presentation/common/providers/deep_link_provider.dart';
@@ -19,8 +20,38 @@ class AppInitializationWrapper extends ConsumerStatefulWidget {
 }
 
 class _AppInitializationWrapperState
-    extends ConsumerState<AppInitializationWrapper> {
+    extends ConsumerState<AppInitializationWrapper>
+    with WidgetsBindingObserver {
   bool _initialLinkHandled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _restartSync();
+    }
+  }
+
+  void _restartSync() {
+    final groupCode = ref.read(currentGroupCodeProvider);
+
+    if (groupCode == null) return;
+
+    final syncService = ref.read(realtimeSyncServiceProvider);
+    syncService.stopSync();
+    syncService.startSync(groupCode);
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- 앱이 백그라운드에서 포그라운드로 복귀 시 동기화 재시작
- 알림 탭 후 앱 진입 시 최신 데이터 즉시 반영

## Note
- WidgetsBindingObserver로 AppLifecycleState.resumed 감지